### PR TITLE
Some authenticaiton error messages to help with simple errors

### DIFF
--- a/lib/cf_start_stop_environment.rb
+++ b/lib/cf_start_stop_environment.rb
@@ -42,6 +42,10 @@ module Base2
         end
         @dry_run = (ENV.key?('DRY_RUN') and ENV['DRY_RUN'] == '1')
         @continue_on_error = (ENV.key? 'CFN_CONTINUE_ON_ERROR' and ENV['CFN_CONTINUE_ON_ERROR'] == '1')
+      rescue NoMethodError => e
+        puts "Got No Method Error on CloudFormation::initialize, this often means that you're missing a AWS_DEFAULT_REGION"
+      rescue Aws::Sigv4::Errors::MissingCredentialsError => e
+        puts "Got Missing Credentials Error on CloudFormation::initialize, this often means that AWS_PROFILE is unset, or no default credentials were provided."
       end
 
 


### PR DESCRIPTION
See examples:
Without profile
```aubelsb2@arran-yoga ~/CiinaboxProjects/cloudwatcherstatsascodetest
 % /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage start-environment --stack-name ciinabox-cactest  --source-bucket ciinabox-deployment-cactest.reference.ci.base2.services --region  --profile cactest
Got Missing Credentials Error on CloudFormation::initialize, this often means that AWS_PROFILE is unset, or no default credentials were provided.
I, [2018-07-13T12:43:30.082534 #28248]  INFO -- : Starting environment ciinabox-cactest
Traceback (most recent call last):
        4: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage:2:in `<main>'
        3: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage:2:in `require_relative'
        2: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage.rb:98:in `<top (required)>'
        1: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/lib/cf_start_stop_environment.rb:54:in `start_environment'
/mnt/base2/RubymineProjects/cfn-start-stop-stack/lib/cf_common.rb:8:in `visit_stack': undefined method `describe_stack_resources' for nil:NilClass (NoMethodError)
```
Without region
```
aubelsb2@arran-yoga ~/CiinaboxProjects/cloudwatcherstatsascodetest
 % AWS_PROFILE=cactest /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage start-environment --stack-name ciinabox-cactest  --source-bucket ciinabox-deployment-cactest.reference.ci.base2.services --region  --profile cactest
Got No Method Error on CloudFormation::initialize, this often means that you're missing a AWS_DEFAULT_REGION
I, [2018-07-13T12:44:00.068758 #28274]  INFO -- : Starting environment ciinabox-cactest
Traceback (most recent call last):
        4: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage:2:in `<main>'
        3: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage:2:in `require_relative'
        2: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/bin/cfn_manage.rb:98:in `<top (required)>'
        1: from /mnt/base2/RubymineProjects/cfn-start-stop-stack/lib/cf_start_stop_environment.rb:54:in `start_environment'
/mnt/base2/RubymineProjects/cfn-start-stop-stack/lib/cf_common.rb:8:in `visit_stack': undefined method `describe_stack_resources' for nil:NilClass (NoMethodError)
```
Strictly speaking this could be done better with checking, as there are various places, but why re-implement that logic, when the SDK throws for us?