### PR TITLE
bug fix for ecs services stopped outside of cfn_manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ General options:
   This will enabled waiting for resources in groups based on priority. Option only useful when used with
   start-environment and stop-environment commands.
 
+--ignore-missing-ecs-config
+
+    This option is required for starting a ecs service that was stopped outside of cfn_manage.
 ```
 
 ## Environment Variables
@@ -210,6 +213,8 @@ There are command line switch counter parts for all of the
 `SOURCE_BUCKET` as env var or `--source-bucket` as CLI switch
 
 `DRY_RUN` as env var (set to '1' to enable) or `--dry-run` as CLI switch
+
+`IGNORE_MISSING_ECS_CONFIG` as env var (set to '1' to enable) or `--ignore-missing-ecs-config` as CLI switch
 
 ## Release process
 

--- a/bin/cfn_manage
+++ b/bin/cfn_manage
@@ -91,8 +91,12 @@ OptionParser.new do |opts|
     ENV['SKIP_WAIT'] = '1'
   end
 
-  opts.on('--skip_wait') do
+  opts.on('--skip-wait') do
     ENV['SKIP_WAIT'] = '1'
+  end
+
+  opts.on('--ignore-missing-ecs-config') do
+    ENV['IGNORE_MISSING_ECS_CONFIG'] = '1'
   end
 
 end.parse!

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -77,6 +77,10 @@ General options:
 
 --wait-async
 
-  Default wait action is to wait for each individual resource to be stopped and started before continuing.
-  This will enabled waiting for resources in groups based on priority. Option only useful when used with
-  start-environment and stop-environment commands.
+    Default wait action is to wait for each individual resource to be stopped and started before continuing.
+    This will enabled waiting for resources in groups based on priority. Option only useful when used with
+    start-environment and stop-environment commands.
+
+--ignore-missing-ecs-config
+
+    This option is required for starting a ecs service that was stopped outside of cfn_manage.

--- a/lib/cfn_manage/version.rb
+++ b/lib/cfn_manage/version.rb
@@ -1,3 +1,3 @@
 module CfnManage
-  VERSION="0.5.0".freeze
+  VERSION="0.5.1".freeze
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,7 +1,7 @@
 require 'cfn_manage/version'
 
 describe 'Version' do
-  it 'is version 0.5.0' do
-    expect(CfnManage::VERSION).to eq("0.5.0")
+  it 'is version 0.5.1' do
+    expect(CfnManage::VERSION).to eq("0.5.1")
   end
 end


### PR DESCRIPTION
Introduced option `--ignore-missing-ecs-config` to start ecs services stopped outside of cfn_manage