### PR TITLE
ability to specify wait types of asg instances

### DIFF
--- a/bin/cfn_manage
+++ b/bin/cfn_manage
@@ -77,6 +77,15 @@ OptionParser.new do |opts|
   opts.on('--alarm [ALARM]') do |alarm|
     $options['ALARM'] = alarm
   end
+  
+  opts.on('--asg-wait-type [WAIT_TYPE]') do |type|
+    allows_values = ['HealthyInASG','Running','HealthyInTargetGroup']
+    if !allows_values.include? type
+      STDERR.puts("#{type} is not a valid value for `--asg-wait-type`. Use one of #{allows_values.join(',')}")
+      exit 1
+    end
+    ENV['ASG_WAIT_TYPE'] = type
+  end
 
   opts.on('-r [AWS_REGION]', '--region [AWS_REGION]') do |region|
     ENV['AWS_REGION'] = region

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -96,3 +96,12 @@ General options:
 --asg-suspend-termination
 
     Will stop instances in the autoscaling group(s) instead of the default behaviour of termination.
+
+--asg-wait-type
+    
+    Allowed values ['HealthyInASG','Running','HealthyInTargetGroup']
+    Default: 'HealthyInASG'
+    
+    'HealthyInASG' - waits for all instances to reach a healthy state in the asg
+    'Running' - waits for all instances to reach the EC2 running state
+    'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups

--- a/cfn_manage.gemspec
+++ b/cfn_manage.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-ecs', '~> 1', '<2'
   spec.add_runtime_dependency 'aws-sdk-docdb', '>=1.9.0', '<2'
   spec.add_runtime_dependency 'aws-sdk-transfer', '~>1', '<2'
-
+  spec.add_runtime_dependency 'aws-sdk-elasticloadbalancingv2', '~>1', '<2'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/cfn_manage/asg_start_stop_handler.rb
+++ b/lib/cfn_manage/asg_start_stop_handler.rb
@@ -217,6 +217,11 @@ module CfnManage
       asg_status = asg_curr_details.auto_scaling_groups.first
       instances = asg_status.instances.collect { |inst| inst.instance_id }
       
+      if instances.empty?
+        $log.warn("ASG #{@asg_name} has not started any instances yet")
+        return true
+      end
+      
       status = @ec2_client.describe_instance_status({
         instance_ids: instances
       })

--- a/lib/cfn_manage/cf_start_stop_environment.rb
+++ b/lib/cfn_manage/cf_start_stop_environment.rb
@@ -168,7 +168,7 @@ module CfnManage
                 # read configuration
                 s3_prefix = "environment_data/resource/#{resource[:id]}"
                 configuration = get_object_configuration(s3_prefix)
-
+                
                 # start
                 resource[:handler].start(configuration)
               else
@@ -231,7 +231,7 @@ module CfnManage
       end
 
       def get_object_configuration(s3_prefix)
-        configuration = nil
+        configuration = {}
         begin
           key = "#{s3_prefix}/latest/config.json"
           $log.info("Reading object configuration from s3://#{@s3_bucket}/#{key}")


### PR DESCRIPTION
command line flag to set asg wait types

```
--asg-wait-type
    
    Allowed values ['HealthyInASG','Running','HealthyInTargetGroup']
    Default: 'HealthyInASG'
    
    'HealthyInASG' - waits for all instances to reach a healthy state in the asg
    'Running' - waits for all instances to reach the EC2 running state
    'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups
```