### PR TITLE
Ability to define start order by tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,21 @@ General options:
 --asg-suspend-termination
 
     Will stop instances in the autoscaling group(s) instead of the default behaviour of termination.
+    
+--asg-wait-type
+    
+    Allowed values ['HealthyInASG','Running','HealthyInTargetGroup']
+    Default: 'HealthyInASG'
+    
+    'HealthyInASG' - waits for all instances to reach a healthy state in the asg
+    'Running' - waits for all instances to reach the EC2 running state
+    'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups
+    
+--tags
+
+    will query resource tags for individual resource settings.
+        `cfn_manage:priority` for prefered starting order
+    will default to defined resource order if no tag is found or resource doesn't support tags
 ```
 
 ## Environment Variables

--- a/bin/cfn_manage
+++ b/bin/cfn_manage
@@ -119,6 +119,10 @@ OptionParser.new do |opts|
   opts.on('--asg-suspend-termination') do
     ENV['ASG_SUSPEND_TERMINATION'] = '1'
   end
+  
+  opts.on('--by-tags') do
+    ENV['ORDER_BY_TAGS'] = '1'
+  end
 
 end.parse!
 

--- a/bin/cfn_manage
+++ b/bin/cfn_manage
@@ -106,10 +106,12 @@ OptionParser.new do |opts|
   opts.on('--wait-async') do
     ENV['WAIT_ASYNC'] = '1'
     ENV['SKIP_WAIT'] = '1'
+    CfnManage.skip_wait
   end
 
   opts.on('--skip-wait') do
     ENV['SKIP_WAIT'] = '1'
+    CfnManage.skip_wait
   end
 
   opts.on('--ignore-missing-ecs-config') do
@@ -120,8 +122,8 @@ OptionParser.new do |opts|
     ENV['ASG_SUSPEND_TERMINATION'] = '1'
   end
   
-  opts.on('--by-tags') do
-    ENV['ORDER_BY_TAGS'] = '1'
+  opts.on('--tags') do
+    CfnManage.find_tags
   end
 
 end.parse!

--- a/bin/cfn_manage
+++ b/bin/cfn_manage
@@ -77,6 +77,15 @@ OptionParser.new do |opts|
   opts.on('--alarm [ALARM]') do |alarm|
     $options['ALARM'] = alarm
   end
+  
+  opts.on('--asg-wait-type [WAIT_TYPE]') do |type|
+    allows_values = ['HealthyInASG','Running','HealthyInTargetGroup']
+    if !allows_values.include? type
+      STDERR.puts("#{type} is not a valid value for `--asg-wait-type`. Use one of #{allows_values.join(',')}")
+      exit 1
+    end
+    ENV['ASG_WAIT_TYPE'] = type
+  end
 
   opts.on('-r [AWS_REGION]', '--region [AWS_REGION]') do |region|
     ENV['AWS_REGION'] = region

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -96,3 +96,12 @@ General options:
 --asg-suspend-termination
 
     Will stop instances in the autoscaling group(s) instead of the default behaviour of termination.
+
+--asg-wait-type
+    
+    Allowed values ['HealthyInASG','Running','HealthyInTargetGroup']
+    Default: 'HealthyInASG'
+    
+    'HealthyInASG' - waits for all instances to reach a healthy state in the asg
+    'Running' - waits for all instances to reach the EC2 running state
+    'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -105,3 +105,8 @@ General options:
     'HealthyInASG' - waits for all instances to reach a healthy state in the asg
     'Running' - waits for all instances to reach the EC2 running state
     'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups
+    
+--by-tags
+
+    will query resource tag `cfn_manage:priority` for prefered starting order
+    will default to defined resource order if no tag is found or resource doesn't support tags

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -106,7 +106,8 @@ General options:
     'Running' - waits for all instances to reach the EC2 running state
     'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups
     
---by-tags
+--tags
 
-    will query resource tag `cfn_manage:priority` for prefered starting order
+    will query resource tags for individual resource settings.
+        `cfn_manage:priority` for prefered starting order
     will default to defined resource order if no tag is found or resource doesn't support tags

--- a/cfn_manage.gemspec
+++ b/cfn_manage.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-ecs', '~> 1', '<2'
   spec.add_runtime_dependency 'aws-sdk-docdb', '>=1.9.0', '<2'
   spec.add_runtime_dependency 'aws-sdk-transfer', '~>1', '<2'
-
+  spec.add_runtime_dependency 'aws-sdk-elasticloadbalancingv2', '~>1', '<2'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/cfn_manage/asg_start_stop_handler.rb
+++ b/lib/cfn_manage/asg_start_stop_handler.rb
@@ -1,4 +1,6 @@
 require 'cfn_manage/aws_credentials'
+require 'cfn_manage/globals'
+require 'cfn_manage/tag_reader'
 
 require 'aws-sdk-autoscaling'
 require 'aws-sdk-ec2'
@@ -11,7 +13,7 @@ module CfnManage
     def initialize(asg_id, skip_wait)
       @asg_name = asg_id
       @skip_wait = skip_wait
-      @asg_suspend_termination = (ENV.key?('ASG_SUSPEND_TERMINATION') and ENV['ASG_SUSPEND_TERMINATION'] == '1')
+      @asg_suspend_termination = (ENV.key?('ASG_SUSPEND_TERMINATION') && ENV['ASG_SUSPEND_TERMINATION'] == '1')
       @wait_type = ENV.key?('ASG_WAIT_TYPE') ? ENV['ASG_WAIT_TYPE'] : 'HealthyInASG'
       credentials = CfnManage::AWSCredentials.get_session_credentials("stopasg_#{@asg_name}")
       @asg_client = Aws::AutoScaling::Client.new(retry_limit: 20)

--- a/lib/cfn_manage/asg_start_stop_handler.rb
+++ b/lib/cfn_manage/asg_start_stop_handler.rb
@@ -217,6 +217,11 @@ module CfnManage
       asg_status = asg_curr_details.auto_scaling_groups.first
       instances = asg_status.instances.collect { |inst| inst.instance_id }
       
+      if instances.empty?
+        $log.warn("ASG #{@asg_name} has not started any instances yet")
+        return true
+      end
+      
       status = @ec2_client.describe_instance_status({
         instance_ids: instances
       })

--- a/lib/cfn_manage/cf_start_stop_environment.rb
+++ b/lib/cfn_manage/cf_start_stop_environment.rb
@@ -157,7 +157,7 @@ module CfnManage
                 # read configuration
                 s3_prefix = "environment_data/resource/#{resource[:id]}"
                 configuration = get_object_configuration(s3_prefix)
-
+                
                 # start
                 resource[:handler].start(configuration)
               else
@@ -222,7 +222,7 @@ module CfnManage
       end
 
       def get_object_configuration(s3_prefix)
-        configuration = nil
+        configuration = {}
         begin
           key = "#{s3_prefix}/latest/config.json"
           $log.info("Reading object configuration from s3://#{@s3_bucket}/#{key}")

--- a/lib/cfn_manage/globals.rb
+++ b/lib/cfn_manage/globals.rb
@@ -1,0 +1,22 @@
+module CfnManage
+  module_function
+  
+  # find options set on resource tags
+  def find_tags
+    @find_tags = true
+  end
+
+  def find_tags?
+    @find_tags
+  end
+
+  # dont wait for resources to become healthy
+  def skip_wait
+    @skip_wait = true
+  end
+  
+  def skip_wait?
+    @skip_wait
+  end
+  
+end

--- a/lib/cfn_manage/priority.rb
+++ b/lib/cfn_manage/priority.rb
@@ -1,0 +1,61 @@
+require 'cfn_manage/aws_credentials'
+require 'cfn_manage/asg_start_stop_handler'
+
+module CfnManage
+  class Priority
+      
+    def initialize()
+      @priority_by_tags = (ENV.key? 'ORDER_BY_TAGS' and ENV['ORDER_BY_TAGS'] == '1')
+      @credentials = CfnManage::AWSCredentials.get_session_credentials("cfn_manage_get_tags")
+      @default_priorities = {
+        'AWS::RDS::DBInstance' => '100',
+        'AWS::RDS::DBCluster' => '100',
+        'AWS::DocDB::DBCluster' => '100',
+        'AWS::AutoScaling::AutoScalingGroup' => '200',
+        'AWS::EC2::Instance' => '200',
+        'AWS::EC2::SpotFleet' => '200',
+        'AWS::Transfer::Server' => '200',
+        'AWS::ECS::Cluster' => '250',
+        'AWS::CloudWatch::Alarm' => '300'
+      }
+    end
+  
+    def get_priority(resource_type, resource_id)
+
+      priority = nil
+      
+      if @priority_by_tags
+    
+        case resource_type
+        when 'AWS::AutoScaling::AutoScalingGroup'
+          tags = get_asg_tags(resource_id)
+          priority = get_priority_tag(tags[:tags])
+        end
+
+      end
+      
+      if priority.nil?
+        return @default_priorities[resource_id]      
+      end
+      
+      return priority
+    end
+    
+    def get_priority_tag(tags)
+      tags.select {|tag| tag[:key] == 'cfn_manage:priority'}.collect {|tag| tag[:value]}.first
+    end
+    
+    def get_asg_tags()
+      client = Aws::AutoScaling::Client.new(credentials: @credentials, retry_limit: 20)
+      resp = client.describe_tags({
+        filters: [
+          {
+            name: "auto-scaling-group", 
+            values: [@asg_name]
+          }
+        ]
+      })
+    end
+  
+  end
+end

--- a/lib/cfn_manage/priority.rb
+++ b/lib/cfn_manage/priority.rb
@@ -29,7 +29,7 @@ module CfnManage
         case resource_type
         when 'AWS::AutoScaling::AutoScalingGroup'
           tags = get_asg_tags(resource_id)
-          priority = get_priority_tag(tags[:tags])
+          priority = get_priority_tag(tags)
         end
 
       end
@@ -42,7 +42,7 @@ module CfnManage
     end
     
     def get_priority_tag(tags)
-      tags.select {|tag| tag[:key] == 'cfn_manage:priority'}.collect {|tag| tag[:value]}.first
+      tags.select {|tag| tag.key == 'cfn_manage:priority'}.collect {|tag| tag.value}.first
     end
     
     def get_asg_tags()
@@ -55,6 +55,7 @@ module CfnManage
           }
         ]
       })
+      return resp.tags
     end
   
   end

--- a/lib/cfn_manage/priority.rb
+++ b/lib/cfn_manage/priority.rb
@@ -1,61 +1,45 @@
 require 'cfn_manage/aws_credentials'
-require 'cfn_manage/asg_start_stop_handler'
+require 'cfn_manage/tag_reader'
+require 'cfn_manage/globals'
 
 module CfnManage
   class Priority
       
-    def initialize()
-      @priority_by_tags = (ENV.key? 'ORDER_BY_TAGS' and ENV['ORDER_BY_TAGS'] == '1')
-      @credentials = CfnManage::AWSCredentials.get_session_credentials("cfn_manage_get_tags")
-      @default_priorities = {
-        'AWS::RDS::DBInstance' => '100',
-        'AWS::RDS::DBCluster' => '100',
-        'AWS::DocDB::DBCluster' => '100',
-        'AWS::AutoScaling::AutoScalingGroup' => '200',
-        'AWS::EC2::Instance' => '200',
-        'AWS::EC2::SpotFleet' => '200',
-        'AWS::Transfer::Server' => '200',
-        'AWS::ECS::Cluster' => '250',
-        'AWS::CloudWatch::Alarm' => '300'
-      }
-    end
+    @defaults = {
+      'AWS::RDS::DBInstance' => '100',
+      'AWS::RDS::DBCluster' => '100',
+      'AWS::DocDB::DBCluster' => '100',
+      'AWS::AutoScaling::AutoScalingGroup' => '200',
+      'AWS::EC2::Instance' => '200',
+      'AWS::EC2::SpotFleet' => '200',
+      'AWS::Transfer::Server' => '200',
+      'AWS::ECS::Cluster' => '250',
+      'AWS::CloudWatch::Alarm' => '300'
+    }
   
-    def get_priority(resource_type, resource_id)
+    def self.get_priority(resource_type, resource_id)
 
       priority = nil
       
-      if @priority_by_tags
+      if CfnManage.find_tags?
+        
+        $log.info("Looking for prority set by tags, will return default if tag is not found")
     
         case resource_type
         when 'AWS::AutoScaling::AutoScalingGroup'
-          tags = get_asg_tags(resource_id)
-          priority = get_priority_tag(tags)
+          tags = CfnManage::TagReader.asg(resource_id)
+          priority = CfnManage::TagReader.filter_by_key(tags,'cfn_manage:priority')
         end
 
       end
       
       if priority.nil?
-        return @default_priorities[resource_id]      
+        priority = @defaults[resource_type]      
       end
       
+      $log.debug("type: #{resource_type}, id: #{resource_id}, priority: #{priority}")
+      
       return priority
-    end
-    
-    def get_priority_tag(tags)
-      tags.select {|tag| tag.key == 'cfn_manage:priority'}.collect {|tag| tag.value}.first
-    end
-    
-    def get_asg_tags()
-      client = Aws::AutoScaling::Client.new(credentials: @credentials, retry_limit: 20)
-      resp = client.describe_tags({
-        filters: [
-          {
-            name: "auto-scaling-group", 
-            values: [@asg_name]
-          }
-        ]
-      })
-      return resp.tags
     end
   
   end

--- a/lib/cfn_manage/tag_reader.rb
+++ b/lib/cfn_manage/tag_reader.rb
@@ -1,0 +1,28 @@
+require 'cfn_manage/aws_credentials'
+require 'cfn_manage/asg_start_stop_handler'
+
+module CfnManage
+  class TagReader
+    class << self
+      
+      def filter_by_key(tags,key)
+        tags.select {|tag| tag.key == key}.collect {|tag| tag.value}.first
+      end
+      
+      def asg(resource_id)
+        credentials = CfnManage::AWSCredentials.get_session_credentials("cfn_manage_get_tags")
+        client = Aws::AutoScaling::Client.new(credentials: credentials, retry_limit: 20)
+        resp = client.describe_tags({
+          filters: [
+            {
+              name: "auto-scaling-group", 
+              values: [resource_id]
+            }
+          ]
+        })
+        return resp.tags
+      end
+      
+    end
+  end
+end

--- a/test/test_templates/ecs.yaml
+++ b/test/test_templates/ecs.yaml
@@ -1,60 +1,38 @@
 AWSTemplateFormatVersion: '2010-09-09'
+
 Parameters:
-  KeyName:
-    Type: AWS::EC2::KeyPair::KeyName
-    Description: Name of an existing EC2 KeyPair to enable SSH access to the ECS instances.
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: Select a VPC that allows instances access to the Internet.
   SubnetId:
     Type: List<AWS::EC2::Subnet::Id>
     Description: Select at two subnets in your selected VPC.
-  DesiredCapacity:
-    Type: Number
-    Default: '1'
-    Description: Number of instances to launch in your ECS cluster.
-  MaxSize:
-    Type: Number
-    Default: '1'
-    Description: Maximum number of instances that can be launched in your ECS cluster.
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t2.micro
-    AllowedValues: [t2.micro, t2.small, t2.medium, t2.large, m3.medium, m3.large,
-      m3.xlarge, m3.2xlarge, m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m4.10xlarge,
-      c4.large, c4.xlarge, c4.2xlarge, c4.4xlarge, c4.8xlarge, c3.large, c3.xlarge,
-      c3.2xlarge, c3.4xlarge, c3.8xlarge, r3.large, r3.xlarge, r3.2xlarge, r3.4xlarge,
-      r3.8xlarge, i2.xlarge, i2.2xlarge, i2.4xlarge, i2.8xlarge]
+    Default: t3.micro
+    AllowedValues: [t3.micro, t3.small, t3.medium]
     ConstraintDescription: Please choose a valid instance type.
-Mappings:
-  AWSRegionToAMI:
-    us-east-1:
-      AMIID: ami-eca289fb
-    us-east-2:
-      AMIID: ami-446f3521
-    us-west-1:
-      AMIID: ami-9fadf8ff
-    us-west-2:
-      AMIID: ami-7abc111a
-    eu-west-1:
-      AMIID: ami-a1491ad2
-    eu-central-1:
-      AMIID: ami-54f5303b
-    ap-northeast-1:
-      AMIID: ami-9cd57ffd
-    ap-southeast-1:
-      AMIID: ami-a900a3ca
-    ap-southeast-2:
-      AMIID: ami-5781be34
+  EcsAmi:
+    Description: ECS Ami
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+  AsgAmi:
+    Description: ECS Ami
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+    
 Resources:
+  
   ECSCluster:
     Type: AWS::ECS::Cluster
+    
   EcsSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: ECS Security Group
       VpcId: !Ref 'VpcId'
+      
   EcsSecurityGroupHTTPinbound:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -63,14 +41,7 @@ Resources:
       FromPort: '80'
       ToPort: '80'
       CidrIp: 0.0.0.0/0
-  EcsSecurityGroupSSHinbound:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !Ref 'EcsSecurityGroup'
-      IpProtocol: tcp
-      FromPort: '22'
-      ToPort: '22'
-      CidrIp: 0.0.0.0/0
+      
   EcsSecurityGroupALBports:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -79,11 +50,13 @@ Resources:
       FromPort: '31000'
       ToPort: '61000'
       SourceSecurityGroupId: !Ref 'EcsSecurityGroup'
+      
   CloudwatchLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Join ['-', [ECSLogGroup, !Ref 'AWS::StackName']]
       RetentionInDays: 14
+      
   taskdefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -128,16 +101,17 @@ Resources:
         - SourceContainer: simple-app
       Volumes:
       - Name: my-vol
+      
   ECSALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: ECSALB
       Scheme: internet-facing
       LoadBalancerAttributes:
       - Key: idle_timeout.timeout_seconds
         Value: '30'
       Subnets: !Ref 'SubnetId'
       SecurityGroups: [!Ref 'EcsSecurityGroup']
+      
   ALBListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     DependsOn: ECSServiceRole
@@ -148,6 +122,7 @@ Resources:
       LoadBalancerArn: !Ref 'ECSALB'
       Port: '80'
       Protocol: HTTP
+      
   ECSALBListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     DependsOn: ALBListener
@@ -159,7 +134,8 @@ Resources:
       - Field: path-pattern
         Values: [/]
       ListenerArn: !Ref 'ALBListener'
-      Priority: 1
+      Priority: 100
+      
   ECSTG:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: ECSALB
@@ -169,39 +145,37 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: ECSTG
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId: !Ref 'VpcId'
+      
   ECSAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier: !Ref 'SubnetId'
       LaunchConfigurationName: !Ref 'ContainerInstances'
       MinSize: '1'
-      MaxSize: !Ref 'MaxSize'
-      DesiredCapacity: !Ref 'DesiredCapacity'
-    CreationPolicy:
-      ResourceSignal:
-        Timeout: PT15M
-    UpdatePolicy:
-      AutoScalingReplacingUpdate:
-        WillReplace: 'true'
+      MaxSize: '2'
+      DesiredCapacity: '1'
+      Tags:
+        - Key: Name
+          PropagateAtLaunch: true
+          Value: ecs-xx
+
+        
   ContainerInstances:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      ImageId: !FindInMap [AWSRegionToAMI, !Ref 'AWS::Region', AMIID]
+      ImageId: !Ref EcsAmi
       SecurityGroups: [!Ref 'EcsSecurityGroup']
       InstanceType: !Ref 'InstanceType'
       IamInstanceProfile: !Ref 'EC2InstanceProfile'
-      KeyName: !Ref 'KeyName'
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -xe
           echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
-          yum install -y aws-cfn-bootstrap
-          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}
+          
   service:
     Type: AWS::ECS::Service
     DependsOn: ALBListener
@@ -214,6 +188,7 @@ Resources:
         TargetGroupArn: !Ref 'ECSTG'
       Role: !Ref 'ECSServiceRole'
       TaskDefinition: !Ref 'taskdefinition'
+      
   ECSServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -233,46 +208,7 @@ Resources:
               'elasticloadbalancing:Describe*', 'elasticloadbalancing:RegisterInstancesWithLoadBalancer',
               'elasticloadbalancing:RegisterTargets', 'ec2:Describe*', 'ec2:AuthorizeSecurityGroupIngress']
             Resource: '*'
-  ServiceScalingTarget:
-    Type: AWS::ApplicationAutoScaling::ScalableTarget
-    DependsOn: service
-    Properties:
-      MaxCapacity: 2
-      MinCapacity: 1
-      ResourceId: !Join ['', [service/, !Ref 'ECSCluster', /, !GetAtt [service, Name]]]
-      RoleARN: !GetAtt [AutoscalingRole, Arn]
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-  ServiceScalingPolicy:
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: AStepPolicy
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref 'ServiceScalingTarget'
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 60
-        MetricAggregationType: Average
-        StepAdjustments:
-        - MetricIntervalLowerBound: 0
-          ScalingAdjustment: 200
-  ALB500sAlarmScaleUp:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      EvaluationPeriods: '1'
-      Statistic: Average
-      Threshold: '10'
-      AlarmDescription: Alarm if our ALB generates too many HTTP 500s.
-      Period: '60'
-      AlarmActions: [!Ref 'ServiceScalingPolicy']
-      Namespace: AWS/ApplicationELB
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !GetAtt
-            - ECSALB
-            - LoadBalancerFullName
-      ComparisonOperator: GreaterThanThreshold
-      MetricName: HTTPCode_ELB_5XX_Count
+  
   EC2Role:
     Type: AWS::IAM::Role
     Properties:
@@ -292,29 +228,79 @@ Resources:
               'ecs:Poll', 'ecs:RegisterContainerInstance', 'ecs:StartTelemetrySession',
               'ecs:Submit*', 'logs:CreateLogStream', 'logs:PutLogEvents']
             Resource: '*'
-  AutoscalingRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: [application-autoscaling.amazonaws.com]
-          Action: ['sts:AssumeRole']
-      Path: /
-      Policies:
-      - PolicyName: service-autoscaling
-        PolicyDocument:
-          Statement:
           - Effect: Allow
-            Action: ['application-autoscaling:*', 'cloudwatch:DescribeAlarms', 'cloudwatch:PutMetricAlarm',
-              'ecs:DescribeServices', 'ecs:UpdateService']
+            Action: ['elasticloadbalancing:DeregisterInstancesFromLoadBalancer', 'elasticloadbalancing:DeregisterTargets',
+              'elasticloadbalancing:Describe*', 'elasticloadbalancing:RegisterInstancesWithLoadBalancer',
+              'elasticloadbalancing:RegisterTargets', 'ec2:Describe*', 'ec2:AuthorizeSecurityGroupIngress']
             Resource: '*'
+            
   EC2InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles: [!Ref 'EC2Role']
+  
+  EC2AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      VPCZoneIdentifier: !Ref 'SubnetId'
+      LaunchConfigurationName: !Ref 'EC2Instances'
+      MinSize: '1'
+      MaxSize: '2'
+      DesiredCapacity: '1'
+      TargetGroupARNs:
+        - !Ref EC2TG
+      Tags:
+        - Key: Name
+          PropagateAtLaunch: true
+          Value: ec2-nginx-xx
+        - Key: cfn_manage:priority
+          PropagateAtLaunch: false
+          Value: 120
+        
+  EC2Instances:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      ImageId: !Ref AsgAmi
+      SecurityGroups: [!Ref 'EcsSecurityGroup']
+      InstanceType: !Ref 'InstanceType'
+      IamInstanceProfile: !Ref 'EC2InstanceProfile'
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash -xe
+          amazon-linux-extras install nginx1.12
+          systemctl start nginx
+  
+  EC2ALBListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn: ALBListener
+    Properties:
+      Actions:
+      - Type: forward
+        TargetGroupArn: !Ref 'EC2TG'
+      Conditions:
+      - Field: host-header
+        Values: ['nginix.*']
+      ListenerArn: !Ref 'ALBListener'
+      Priority: 10
+      
+  EC2TG:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn: ECSALB
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      Port: 80
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      VpcId: !Ref 'VpcId'
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 0
+            
 Outputs:
   ecsservice:
     Value: !Ref 'service'


### PR DESCRIPTION
set `cfn_manage:priority` => (int) on a ASG tag to change the priority order of that individual resource. The default behaviour is to use the defaults provided in the priority.rb class.

This PR is for ASG resources only.