### PR TITLE
support for ecs service wait states and ecs cluster tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In case of some configuration data being lost, script will continue and work wit
 removed from S3, but rds data persists will results in RDS instances being started)
 
 Order of operations is supported at this point as hardcoded weights per resource type. Pull Requests are welcome
-for supporting dynamic discovery of order of execution - resource tags or local configuration file override are some of
+for supporting dynamic discovery of order of execution - local configuration file override is one of
 the possible sources.
 
 
@@ -112,6 +112,12 @@ it will get converted to Multi-AZ prior being started
 **Stop** operation will set spot fleet target to capacity to 0
 
 **Start** operation will restore spot fleet target to capacity to what was set prior the stack being stopped.
+
+#### AWS::ECS::Cluster
+
+**Stop** operation will query all services running in the cluster and set desired capacity to 0
+
+**Start** operation will query all services assocated with the cluster restore desired capacity to what was set prior the stack being stopped.
 
 ## CLI usage
 
@@ -213,7 +219,7 @@ General options:
 
     Will stop instances in the autoscaling group(s) instead of the default behaviour of termination.
     
---asg-wait-type
+--asg-wait-state
     
     Allowed values ['HealthyInASG','Running','HealthyInTargetGroup']
     Default: 'HealthyInASG'
@@ -221,12 +227,24 @@ General options:
     'HealthyInASG' - waits for all instances to reach a healthy state in the asg
     'Running' - waits for all instances to reach the EC2 running state
     'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups
+
+--ecs-wait-state
     
+    Allowed values ['Running','HealthyInTargetGroup']
+    Default: 'Skip'
+    
+    'Running' - waits for all ecs services in cluster to reach the running state
+    'HealthyInTargetGroup' - waits for all ecs services in cluster to reach a healthy state in all assocated target groups
+            
 --tags
 
     will query resource tags for individual resource settings.
         `cfn_manage:priority` for prefered starting order
     will default to defined resource order if no tag is found or resource doesn't support tags
+    
+--ecs-wait-container-instances
+    
+    waits for a container instance to be active in the ecs cluster before starting services
 ```
 
 ## Environment Variables
@@ -245,6 +263,39 @@ There are command line switch counter parts for all of the
 `DRY_RUN` as env var (set to '1' to enable) or `--dry-run` as CLI switch
 
 `IGNORE_MISSING_ECS_CONFIG` as env var (set to '1' to enable) or `--ignore-missing-ecs-config` as CLI switch
+
+`CFN_CONTINUE_ON_ERROR` as env var (set to '1' to enable) or `--continue-on-error` as CLI switch
+
+`SKIP_WAIT` as env var (set to '1' to enable) or `--skip-wait` as CLI switch
+
+`WAIT_ASYNC` as env var (set to '1' to enable) or `--wait-async` as CLI switch
+
+`ASG_SUSPEND_TERMINATION` as env var (set to '1' to enable) or `--asg-suspend-termination` as CLI switch
+
+`CFN_TAGS` as env var (set to '1' to enable) or `--tags` as CLI switch
+
+`ECS_WAIT_CONTAINER_INSTANCES` as env var (set to '1' to enable) or `--ecs-wait-container-instances` as CLI switch
+
+## AWS Resource Tags
+
+will query resource tags for individual resource settings. please see bellow the list of resources currently supported by tags and their options.
+
+#### AWS::AutoScaling::AutoScalingGroup'
+
+```yaml
+cfn_manage:wait_state: 'HealthyInASG'
+cfn_manage:skip_wait: true
+cfn_manage:suspend_termination: true
+```
+
+#### AWS::ECS::Cluster
+
+```yaml
+cfn_manage:wait_state: 'Running'
+cfn_manage:skip_wait: true
+cfn_manage:wait_container_instances: true
+cfn_manage:ignore_missing_ecs_config: true
+```
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ General options:
     Applicable only to [start|stop-environment] commands. If dry run is enabled
     info about assets being started / stopped will ne only printed to standard output,
     without any action taken.
+    
+--debug
+
+    Displays debug logs
 
 --continue-on-error
 
@@ -275,6 +279,8 @@ There are command line switch counter parts for all of the
 `CFN_TAGS` as env var (set to '1' to enable) or `--tags` as CLI switch
 
 `ECS_WAIT_CONTAINER_INSTANCES` as env var (set to '1' to enable) or `--ecs-wait-container-instances` as CLI switch
+
+`CFN_DEBUG` as env var (set to '1' to enable) or `--debug` as CLI switch
 
 ## AWS Resource Tags
 

--- a/bin/cfn_manage
+++ b/bin/cfn_manage
@@ -88,6 +88,15 @@ OptionParser.new do |opts|
     CfnManage.asg_wait_state = state
   end
 
+  opts.on('--ecs-wait-state [WAIT_STATE]') do |state|
+    allows_values = ['Running','HealthyInTargetGroup']
+    if !allows_values.include? state
+      STDERR.puts("#{type} is not a valid value for `--ecs-wait-state`. Use one of #{allows_values.join(',')}")
+      exit 1
+    end
+    CfnManage.ecs_wait_state = state
+  end
+
   opts.on('-r [AWS_REGION]', '--region [AWS_REGION]') do |region|
     ENV['AWS_REGION'] = region
   end
@@ -154,6 +163,14 @@ OptionParser.new do |opts|
   
   if ENV['CFN_TAGS'] == '1'
     CfnManage.find_tags
+  end
+  
+  opts.on('--ecs-wait-container-instances') do
+    CfnManage.ecs_wait_container_instances
+  end
+  
+  if ENV['ECS_WAIT_CONTAINER_INSTANCES'] == '1'
+    CfnManage.ecs_wait_container_instances
   end
 
 end.parse!

--- a/bin/cfn_manage
+++ b/bin/cfn_manage
@@ -19,6 +19,7 @@ $options['AWS_ASSUME_ROLE'] = ENV['AWS_ASSUME_ROLE']
 
 # global logger
 $log = Logger.new(STDOUT)
+$log.level = Logger::INFO
 
 # always flush output
 STDOUT.sync = true
@@ -113,6 +114,14 @@ OptionParser.new do |opts|
   
   if ENV['DRY_RUN'] == '1'
     CfnManage.dry_run
+  end
+  
+  opts.on('--debug') do
+    $log.level = Logger::DEBUG
+  end
+  
+  if ENV['CFN_DEBUG'] == '1'
+    $log.level = Logger::DEBUGß
   end
 
   opts.on('--continue-on-error') do

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -105,9 +105,21 @@ General options:
     'HealthyInASG' - waits for all instances to reach a healthy state in the asg
     'Running' - waits for all instances to reach the EC2 running state
     'HealthyInTargetGroup' - waits for all instances to reach a healthy state in all asg assocated target groups
+
+--ecs-wait-state
     
+    Allowed values ['Running','HealthyInTargetGroup']
+    Default: 'Skip'
+    
+    'Running' - waits for all ecs services in cluster to reach the running state
+    'HealthyInTargetGroup' - waits for all ecs services in cluster to reach a healthy state in all assocated target groups
+            
 --tags
 
     will query resource tags for individual resource settings.
         `cfn_manage:priority` for prefered starting order
     will default to defined resource order if no tag is found or resource doesn't support tags
+    
+--ecs-wait-container-instances
+    
+    waits for a container instance to be active in the ecs cluster before starting services

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -71,6 +71,10 @@ General options:
     Applicable only to [start|stop-environment] commands. If dry run is enabled
     info about assets being started / stopped will ne only printed to standard output,
     without any action taken.
+    
+--debug
+
+    Displays debug logs
 
 --continue-on-error
 

--- a/lib/cfn_manage/cf_start_stop_environment.rb
+++ b/lib/cfn_manage/cf_start_stop_environment.rb
@@ -26,7 +26,9 @@ module CfnManage
       }
       
       TAGGED_RESOURCES = %w(
-        AWS::AutoScaling::AutoScalingGroup AWS::EC2::Instance
+        AWS::AutoScaling::AutoScalingGroup
+        AWS::EC2::Instance
+        AWS::ECS::Cluster
       )
 
       def initialize()

--- a/lib/cfn_manage/globals.rb
+++ b/lib/cfn_manage/globals.rb
@@ -2,11 +2,17 @@ module CfnManage
   
   # set default options here
   @asg_wait_state = 'HealthyInASG'
+  @ecs_wait_state = 'Skip'
   
   class << self
     
     # return the vale of our options
-    attr_accessor :asg_wait_state
+    attr_accessor :asg_wait_state, :ecs_wait_state
+    
+    # converts string based bolleans from aws tag values to bolleans
+    def true?(obj)
+      ["true","1"].include? obj.to_s.downcase
+    end
     
     # find options set on resource tags
     def find_tags
@@ -69,6 +75,15 @@ module CfnManage
     
     def continue_on_error?
       @continue_on_error
+    end
+    
+    # Wait for a container instances to join a ecs cluster
+    def ecs_wait_container_instances
+      @ecs_wait_container_instances = true
+    end
+    
+    def ecs_wait_container_instances?
+      @ecs_wait_container_instances
     end
     
   end

--- a/lib/cfn_manage/handlers/asg.rb
+++ b/lib/cfn_manage/handlers/asg.rb
@@ -11,8 +11,8 @@ module CfnManage
       def initialize(asg_id, options = {})
         @asg_name = asg_id
         @wait_state = options.has_key?(:wait_state) ? options[:wait_state] : CfnManage.asg_wait_state
-        @skip_wait = options.has_key?(:skip_wait) ? options[:skip_wait] : CfnManage.skip_wait? 
-        @suspend_termination = options.has_key?(:suspend_termination) ? options[:suspend_termination] : CfnManage.asg_suspend_termination?
+        @skip_wait = options.has_key?(:skip_wait) ? CfnManage.true?(options[:skip_wait]) : CfnManage.skip_wait? 
+        @suspend_termination = options.has_key?(:suspend_termination) ? CfnManage.true?(options[:suspend_termination]) : CfnManage.asg_suspend_termination?
         
         credentials = CfnManage::AWSCredentials.get_session_credentials("stopasg_#{@asg_name}")
         @asg_client = Aws::AutoScaling::Client.new(retry_limit: 20)

--- a/lib/cfn_manage/handlers/asg.rb
+++ b/lib/cfn_manage/handlers/asg.rb
@@ -130,7 +130,11 @@ module CfnManage
           
         end
         
-        if @skip_wait && @suspend_termination
+        if configuration['desired_capacity'] == 0
+          # if ASG desired count is purposfully set to 0 and we want to wait for other ASG's
+          # int the stack, then we need to skip wait for this ASG.
+          $log.info("Desired capacity is 0, skipping wait for asg #{@asg_name}")
+        elsif @skip_wait && @suspend_termination
           # If wait is skipped we still need to wait until the instances are healthy in the asg
           # before resuming the processes. This will avoid the asg terminating the instances.
           wait('HealthyInASG')

--- a/lib/cfn_manage/handlers/ecs_cluster.rb
+++ b/lib/cfn_manage/handlers/ecs_cluster.rb
@@ -56,7 +56,10 @@ module CfnManage
 
         end
         
-        if !@skip_wait
+        if desired_count == 0
+          # skip wait if desired count is purposfully set to 0
+          $log.info("Desired capacity is 0, skipping wait for ecs service #{service.service_name}")
+        elsif !@skip_wait
           @services.each do |service_arn|
             wait(@wait_state,service_arn)
           end

--- a/lib/cfn_manage/handlers/ecs_cluster.rb
+++ b/lib/cfn_manage/handlers/ecs_cluster.rb
@@ -148,13 +148,15 @@ module CfnManage
       end
       
       def wait_till_running(service_arn)
+        service_name = service_arn.split('/').last
         service = @ecs_client.describe_services(services:[service_arn], cluster: @cluster).services.first
-        
+                
         if service.running_count > 0
-          $log.info("ecs service #{service_arn} has #{service.running_count} running tasks")
+          $log.info("ecs service #{service_name} has #{service.running_count} running tasks")
+          return true
         end  
         
-        $log.info("waiting for ecs service #{service_arn} to reach a running state")
+        $log.info("waiting for ecs service #{service_name} to reach a running state")
         return false
       end
       

--- a/lib/cfn_manage/handlers/ecs_cluster.rb
+++ b/lib/cfn_manage/handlers/ecs_cluster.rb
@@ -6,8 +6,14 @@ module CfnManage
     class EcsCluster
 
       def initialize(cluster_id, options = {})
+        @wait_state = options.has_key?(:wait_state) ? options[:wait_state] : CfnManage.ecs_wait_state
+        @skip_wait = options.has_key?(:skip_wait) ? CfnManage.true?(options[:skip_wait]) : CfnManage.skip_wait? 
+        @wait_container_instances = options.has_key?(:wait_container_instances) ? CfnManage.true?(options[:wait_container_instances]) : CfnManage.ecs_wait_container_instances? 
+        @ignore_missing_ecs_config = options.has_key?(:ignore_missing_ecs_config) ? CfnManage.true?(options[:ignore_missing_ecs_config]) : CfnManage.ignore_missing_ecs_config?
+        
         credentials = CfnManage::AWSCredentials.get_session_credentials("stoprun_#{cluster_id}")
         @ecs_client = Aws::ECS::Client.new(credentials: credentials, retry_limit: 20)
+        @elb_client = Aws::ElasticLoadBalancingV2::Client.new(credentials: credentials, retry_limit: 20)
         @services = []
         @ecs_client.list_services(cluster: cluster_id, scheduling_strategy: 'REPLICA', max_results: 100).each do |results|
           @services.push(*results.service_arns)
@@ -17,10 +23,14 @@ module CfnManage
       end
 
       def start(configuration)
+        if @wait_container_instances
+          wait_for_instances()
+        end
+        
         @services.each do |service_arn|
 
           $log.info("Searching for ECS service #{service_arn} in cluster #{@cluster}")
-          service = @ecs_client.describe_services(services:[service_arn], cluster: @cluster).services[0]
+          service = @ecs_client.describe_services(services:[service_arn], cluster: @cluster).services.first
 
           if service.desired_count != 0
             $log.info("ECS service #{service.service_name} is already running")
@@ -45,6 +55,12 @@ module CfnManage
           })
 
         end
+        
+        if !@skip_wait
+          @services.each do |service_arn|
+            wait(@wait_state,service_arn)
+          end
+        end
       end
 
       def stop
@@ -52,7 +68,7 @@ module CfnManage
         @services.each do |service_arn|
 
           $log.info("Searching for ECS service #{service_arn} in cluster #{@cluster}")
-          service = @ecs_client.describe_services(services:[service_arn], cluster: @cluster).services[0]
+          service = @ecs_client.describe_services(services:[service_arn], cluster: @cluster).services.first
 
           if service.desired_count == 0
             $log.info("ECS service #{service.service_name} is already stopped")
@@ -72,8 +88,113 @@ module CfnManage
         return configuration.empty? ? nil : configuration
       end
 
-      def wait(completed_status)
-        $log.debug("Not waiting for ECS Services in cluster #{@cluster}")
+      def wait(type,service_arn=nil)
+        
+        if service_arn.nil?
+          $log.warn("unable to wait for #{service_arn} service")
+          return
+        end
+        
+        attempts = 0
+        
+        until attempts == (max_attempts = 60*6) do
+          
+          case type
+          when 'Running'
+            success = wait_till_running(service_arn)
+          when 'HealthyInTargetGroup'
+            success = wait_till_healthy_in_target_group(service_arn)
+          else
+            $log.warn("unknown ecs service wait type #{type}. skipping...")
+            break
+          end
+          
+          if success
+            break
+          end
+          
+          attempts = attempts + 1
+          sleep(15)
+        end
+
+        if attempts == max_attempts
+          $log.error("Failed to wait for ecs service with wait type #{type}")
+        end
+      end
+      
+      def wait_for_instances
+        
+        attempts = 0
+        
+        until attempts == (max_attempts = 60*3) do
+          
+          resp = @ecs_client.list_container_instances({
+            cluster: @cluster,
+            status: "ACTIVE"
+          })
+          
+          if resp.container_instance_arns.any?
+            $log.info("A container instances has joined ecs cluster #{@cluster}")
+            break
+          end
+          
+          attempts = attempts + 1
+          sleep(5)
+        end
+
+        if attempts == max_attempts
+          $log.error("Failed to wait for container instances to join ecs cluster #{@cluster}")
+        end
+      end
+      
+      def wait_till_running(service_arn)
+        service = @ecs_client.describe_services(services:[service_arn], cluster: @cluster).services.first
+        
+        if service.running_count > 0
+          $log.info("ecs service #{service_arn} has #{service.running_count} running tasks")
+        end  
+        
+        $log.info("waiting for ecs service #{service_arn} to reach a running state")
+        return false
+      end
+      
+      def wait_till_healthy_in_target_group(service_arn)
+        service = @ecs_client.describe_services(services:[service_arn], cluster: @cluster).services.first
+        target_groups = service.load_balancers.collect { |lb| lb.target_group_arn }
+        
+        if target_groups.empty?
+          # we want to skip here if the asg is not associated with any target groups
+          $log.info("ecs aervice #{service_arn} is not associated with any target groups")
+          return true
+        end
+        
+        target_health = []
+        target_groups.each do |tg| 
+          resp = @elb_client.describe_target_health({
+            target_group_arn: tg, 
+          })
+          if resp.target_health_descriptions.empty?
+            # we need to wait until a ecs task has been placed into the target group
+            # before we can check it's healthy
+            $log.info("ECS service #{service_arn} hasn't been placed into target group #{tg.split('/')[1]} yet")
+            return false
+          end
+          target_health.push(*resp.target_health_descriptions)
+        end
+              
+        state = target_health.collect {|tg| tg.target_health.state}
+                
+        if state.all? 'healthy'
+          $log.info("All ecs tasks are in a healthy state in target groups #{target_groups.map {|tg| tg.split('/')[1] }}")
+          return true
+        end
+        
+        unhealthy = target_health.select {|tg| tg.target_health.state != 'healthy'}
+        unhealthy.each do |tg|
+          $log.info("waiting for ecs task #{tg.target.id} to be healthy in target group. Current state is #{tg.target_health.state}")
+        end
+        
+        return false
       end
 
     end

--- a/lib/cfn_manage/tag_finder.rb
+++ b/lib/cfn_manage/tag_finder.rb
@@ -47,7 +47,6 @@ module CfnManage
       })
       @tags = resp.tags
     end
-<<<<<<< HEAD
 
     def ec2()
       credentials = CfnManage::AWSCredentials.get_session_credentials("cfn_manage_get_tags")
@@ -61,7 +60,7 @@ module CfnManage
         ]
       })
       @tags = resp.tags
-=======
+    end
       
     def ecs_cluster()
       credentials = CfnManage::AWSCredentials.get_session_credentials("cfn_manage_get_tags")
@@ -72,7 +71,6 @@ module CfnManage
       })
       cluster = resp.clusters.first
       @tags = cluster.tags
->>>>>>> support for ecs service wait states and ecs cluster tagging
     end
 
   end

--- a/lib/cfn_manage/tag_finder.rb
+++ b/lib/cfn_manage/tag_finder.rb
@@ -18,6 +18,8 @@ module CfnManage
         asg()
       when 'AWS::EC2::Instance'
         ec2()
+      when 'AWS::ECS::Cluster'
+        ecs_cluster()
       end
     end
     
@@ -45,6 +47,7 @@ module CfnManage
       })
       @tags = resp.tags
     end
+<<<<<<< HEAD
 
     def ec2()
       credentials = CfnManage::AWSCredentials.get_session_credentials("cfn_manage_get_tags")
@@ -58,6 +61,18 @@ module CfnManage
         ]
       })
       @tags = resp.tags
+=======
+      
+    def ecs_cluster()
+      credentials = CfnManage::AWSCredentials.get_session_credentials("cfn_manage_get_tags")
+      client = Aws::ECS::Client.new(credentials: credentials, retry_limit: 20)
+      resp = client.describe_clusters({
+        clusters: [@resource_id],
+        include: ["TAGS"]
+      })
+      cluster = resp.clusters.first
+      @tags = cluster.tags
+>>>>>>> support for ecs service wait states and ecs cluster tagging
     end
 
   end

--- a/test/test_templates/ecs.yaml
+++ b/test/test_templates/ecs.yaml
@@ -209,6 +209,30 @@ Resources:
               'elasticloadbalancing:RegisterTargets', 'ec2:Describe*', 'ec2:AuthorizeSecurityGroupIngress']
             Resource: '*'
   
+  JobberTaskdefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Join ['', [!Ref 'AWS::StackName', -jobber]]
+      ContainerDefinitions:
+      - Name: jobber
+        Cpu: 10
+        Essential: true
+        Image: jobber
+        Memory: 200
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: jobber
+  
+  JobberService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref 'ECSCluster'
+      DesiredCount: '1'
+      TaskDefinition: !Ref 'JobberTaskdefinition'
+  
   EC2Role:
     Type: AWS::IAM::Role
     Properties:

--- a/test/test_templates/ecs.yaml
+++ b/test/test_templates/ecs.yaml
@@ -178,7 +178,9 @@ Resources:
           
   service:
     Type: AWS::ECS::Service
-    DependsOn: ALBListener
+    DependsOn: 
+      - ALBListener
+      - ECSAutoScalingGroup
     Properties:
       Cluster: !Ref 'ECSCluster'
       DesiredCount: '1'
@@ -228,6 +230,7 @@ Resources:
   
   JobberService:
     Type: AWS::ECS::Service
+    DependsOn: ECSAutoScalingGroup
     Properties:
       Cluster: !Ref 'ECSCluster'
       DesiredCount: '1'


### PR DESCRIPTION
added flags for ecs service wait states and ecs config from tags

```bash
--ecs-wait-state
    
    Allowed values ['Running','HealthyInTargetGroup']
    Default: 'Skip'
    	    
    'Running' - waits for all ecs services in cluster to reach the running state
    'HealthyInTargetGroup' - waits for all ecs services in cluster to reach a healthy state in all assocated target groups
```

```bash
--ecs-wait-container-instances
    
    waits for a container instance to be active in the ecs cluster before starting services
```