### PR TITLE
add ability to set the region for the s3 source bucket

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,9 @@
 name: build image
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - feature/*
     
 jobs:
   build:

--- a/exe/cfn_manage
+++ b/exe/cfn_manage
@@ -102,6 +102,10 @@ OptionParser.new do |opts|
     ENV['AWS_REGION'] = region
   end
 
+  opts.on('--s3-region [AWS_REGION]') do |region|
+    ENV['CFN_S3_REGION'] = region
+  end
+
   opts.on('-p [AWS_PROFILE]', '--profile [AWS_PROFILE]') do |profile|
     ENV['CFN_AWS_PROFILE'] = profile
   end

--- a/exe/usage.txt
+++ b/exe/usage.txt
@@ -50,13 +50,16 @@ General options:
 
 --source-bucket [BUCKET]
 
-    Pucket used to store / pull information from
+    Bucket used to store / pull information from
+
+--s3-region [AWS_REGION]
+
+    AWS Region to use when making accessing the s3 source bucket if in a different region to the stack
 
 --aws-role [ROLE_ARN]
 
     AWS Role to assume when performing operations. Any reads and
     write to source bucket will be performed outside of this role
-
 
 -r [AWS_REGION], --region [AWS_REGION]
 

--- a/exe/usage.txt
+++ b/exe/usage.txt
@@ -54,7 +54,7 @@ General options:
 
 --s3-region [AWS_REGION]
 
-    AWS Region to use when making accessing the s3 source bucket if in a different region to the stack
+    AWS Region to use when source bucket is in a different region to the resource
 
 --aws-role [ROLE_ARN]
 

--- a/lib/cfn_manage/cf_start_stop_environment.rb
+++ b/lib/cfn_manage/cf_start_stop_environment.rb
@@ -33,7 +33,11 @@ module CfnManage
 
       def initialize()
         @environment_resources = []
-        @s3_client = Aws::S3::Client.new(retry_limit: 20)
+        s3_args = {retry_limit: 20}
+        if ENV.has_key?('CFN_S3_REGION')
+          s3_args[:region] = ENV['CFN_S3_REGION']
+        end
+        @s3_client =Aws::S3::Client.new(s3_args)
         @s3_bucket = ENV['SOURCE_BUCKET']
         @cf_client = Aws::CloudFormation::Client.new(retry_limit: 20)
         @credentials = CfnManage::AWSCredentials.get_session_credentials('start_stop_environment')


### PR DESCRIPTION
the use case here is when using the --region option and the source bucket is in a different region to the stack